### PR TITLE
Add color for reaping counter

### DIFF
--- a/CMTimer.lua
+++ b/CMTimer.lua
@@ -1139,7 +1139,14 @@ function MythicPlusTimerCMTimer:Draw(timeCM)
     local mult = 10 ^ 2
     reapingInPercent = math.floor(reapingInPercent * mult + 0.5) / mult
 
-    local reapingText = MythicPlusTimer.L["ReapingIn"] .. ": " .. reapingInPercent .. "%"
+    local colorString = "|cFFFFFFFF"
+    if reapingInPercent < 4 then 
+      colorString = "|cFFFF0000"
+    elseif reapingInPercent < 10 then
+      colorString = "|cFFFFFF00"
+    end
+
+    local reapingText = MythicPlusTimer.L["ReapingIn"] .. ": " .. colorString .. reapingInPercent .. "%" .. "|r"
 
     if MythicPlusTimerDB.config.showAbsoluteNumbers then
       reapingText = reapingText .. " (" .. math.ceil(reapingIn) .. ")"


### PR DESCRIPTION
For more readability and one look understanding, I have added yellow and red colors for reaping percent counter. Yellow color is for indicate that half of total amount already gotten. And red color is for indicate that less than 4% left to next wave. 4% in my opinion good value that indicate "you need about one pack of trash to start a new reaping wave". Feel free to change this values as you wish. I think this change will great for all other users of this awesome addon.