### PR TITLE
Moved getting quest_frame just before it is hidden to work with ElvUI

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -412,8 +412,9 @@ end
 
 -- ---------------------------------------------------------------------------------------------------------------------
 local function on_objectivetracker_change(_, checked)
-  if not checked then
+  if not checked and quest_frame ~= nil then
     quest_frame:SetParent(UIParent)
+    quest_frame = nil
   end
 end
 
@@ -705,7 +706,9 @@ function main.hide_default_tracker()
 
   local in_combat = InCombatLockdown() or UnitAffectingCombat("player")
   if not in_combat then
-    if quest_frame:GetParent() ~= hidden_frame then
+    if quest_frame == nil then
+      -- find quest frame (used to find object tracker, other addons could have moved the tracker frame)
+      quest_frame = main.get_quest_frame(ObjectiveTrackerFrame)
       quest_frame:SetParent(hidden_frame)
     end
     hidden_frame:Hide()
@@ -719,8 +722,9 @@ function main.show_default_tracker()
   end
 
   local in_combat = InCombatLockdown() or UnitAffectingCombat("player")
-  if not in_combat then
+  if not in_combat and quest_frame ~= nil then
     quest_frame:SetParent(UIParent)
+    quest_frame = nil
   end
 end
 
@@ -768,9 +772,6 @@ function main:enable()
   -- create hidden frame (used to hide the objective tracker, otherwise other addons can show the tracker again)
   hidden_frame = CreateFrame("Frame")
   hidden_frame:Hide()
-
-  -- find quest frame (used to find object tracker, other addons could have moved the tracker frame)
-  quest_frame = main.get_quest_frame(ObjectiveTrackerFrame)
 
   -- create config entries if needed
   local best_times = addon.c("best_times")


### PR DESCRIPTION
Hiding the default quest frame was not working with ElvUI enabled.
It seems that ElvUI overwrites ObjectiveTrackerFrame after MythicPlusTimer is setting quest_frame.

Moved the initialization of quest_frame to main.hide_default_tracker, just before it needs to be hidden.