### PR TITLE
Keep objectives hidden when challenge mode completes

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -447,8 +447,6 @@ local function on_challenge_mode_completed()
 
     main.on_challenge_mode_complete(current_run)
   end
-
-  main.show_default_tracker()
 end
 
 -- ---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Addresses #29 

Simply removes the call to `show_default_tracker()` from `on_challenge_mode_completed()`. The objective tracker will instead be restored on the next zone change, in `on_player_entering_world()`